### PR TITLE
cleanup asdf which output

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -67,7 +67,7 @@ resolve_python_path() {
   local pythons=()
 
   local asdf_python
-  if asdf_python=$(asdf which python3); then
+  if asdf_python=$(asdf which python3 2>/dev/null); then
     pythons+=("$asdf_python")
   else
     local global_python


### PR DESCRIPTION
previously if you didn't have the python3 command installed with asdf,
you would see output like:

```
cowsay install latest
unknown command: python3. Perhaps you have to reshim?
```

This hides that output