### PR TITLE
cleanup direnv switch output

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -61,7 +61,7 @@ resolve_python_path() {
 
   # run direnv in $HOME to escape any direnv we might already be in
   if type -P direnv &>/dev/null; then
-    eval "$(direnv export bash)"
+    eval "$(DIRENV_LOG_FORMAT= direnv export bash)"
   fi
 
   local pythons=()


### PR DESCRIPTION
previously if you installed an app in a direnv env you would see output
like:

```
❯ asdf install
direnv: unloading
direnv: unloading
```

This hides that output