### PR TITLE
Support pipx-like --include-deps via ASDF_PYAPP_INCLUDE_DEPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+include_deps

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ This is a non-exhaustive list of Python Applications that work with this plugin.
 
 | App                                                      | Command to add Plugin                                                   | Notes                                                              |
 | -------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [ansible-base](https://pypi.org/project/ansible-base/)   | `asdf plugin add ansible-base https://github.com/amrox/asdf-pyapp.git`  |                                                                    |
-| [ansible-core](https://pypi.org/project/ansible-core/)   | `asdf plugin add ansible-core https://github.com/amrox/asdf-pyapp.git`  |                                                                    |
+| [ansible](https://pypi.org/project/ansible/)             | `ASDF_PYAPP_INCLUDE_DEPS=1 asdf plugin add ansible https://github.com/amrox/asdf-pyapp.git`       | [(info)](#environment-variables) |
+                                                                    |
 | [awscli](https://pypi.org/project/awscli/)               | `asdf plugin add awscli https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
 | [awsebcli](https://pypi.org/project/awsebcli/)           | `asdf plugin add awsebcli https://github.com/amrox/asdf-pyapp.git`      |                                                                    |
 | [aws-sam-cli](https://pypi.org/project/aws-sam-cli/)     | `asdf plugin add aws-sam-cli https://github.com/amrox/asdf-pyapp.git`   |                                                                    |
@@ -59,6 +59,8 @@ This is a non-exhaustive list of Python Applications that work with this plugin.
 | [bpython](https://pypi.org/project/bpython/)             | `asdf plugin add bpython https://github.com/amrox/asdf-pyapp.git`       |                                                                    |
 | [conan](https://pypi.org/project/conan/)                 | `asdf plugin add conan https://github.com/amrox/asdf-pyapp.git`         |                                                                    |
 | [cowsay](https://pypi.org/project/cowsay/)               | `asdf plugin add cowsay https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [dbt](https://pypi.org/project/dbt/)             | `ASDF_PYAPP_INCLUDE_DEPS=1 asdf plugin add dbt https://github.com/amrox/asdf-pyapp.git`       | [(info)](#environment-variables) |
+
 | [doit](https://pypi.org/project/doit/)                   | `asdf plugin add doit https://github.com/amrox/asdf-pyapp.git`          |                                                                    |
 | [flake8](https://pypi.org/project/flake8/)               | `asdf plugin add flake8 https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
 | [hy](https://pypi.org/project/hy/)                       | `asdf plugin add hy https://github.com/amrox/asdf-pyapp.git`            | The latest stable version of hy (0.20.0 atm) requires python > 3.8 |
@@ -70,6 +72,30 @@ This is a non-exhaustive list of Python Applications that work with this plugin.
 | [sphinx](https://pypi.org/project/Sphinx/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
 | [yawsso](https://pypi.org/project/yawsso/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
 | [youtube-dl](https://pypi.org/project/youtube-dl/)       | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+||||||| parent of 17a4c02 (Document ASDF_PYAPP_INCLUDE_DEPS)
+| App                                                      | Command to add Plugin                                                   | Notes |
+| -------------------------------------------------------- | ----------------------------------------------------------------------- | ----- |
+| [ansible-base](https://pypi.org/project/ansible-base/)   | `asdf plugin add ansible-base https://github.com/amrox/asdf-pyapp.git`  |       |
+| [ansible-core](https://pypi.org/project/ansible-core/)   | `asdf plugin add ansible-core https://github.com/amrox/asdf-pyapp.git`  |       |
+| [awscli](https://pypi.org/project/awscli/)               | `asdf plugin add awscli https://github.com/amrox/asdf-pyapp.git`        |       |
+| [awsebcli](https://pypi.org/project/awsebcli/)           | `asdf plugin add awsebcli https://github.com/amrox/asdf-pyapp.git`      |       |
+| [aws-sam-cli](https://pypi.org/project/aws-sam-cli/)     | `asdf plugin add aws-sam-cli https://github.com/amrox/asdf-pyapp.git`   |       |
+| [aws-ssm-tools](https://pypi.org/project/aws-ssm-tools/) | `asdf plugin add aws-ssm-tools https://github.com/amrox/asdf-pyapp.git` |       |
+| [black](https://pypi.org/project/black/)                 | `asdf plugin add black https://github.com/amrox/asdf-pyapp.git`         |       |
+| [bpython](https://pypi.org/project/bpython/)             | `asdf plugin add bpython https://github.com/amrox/asdf-pyapp.git`       |       |
+| [conan](https://pypi.org/project/conan/)                 | `asdf plugin add conan https://github.com/amrox/asdf-pyapp.git`         |       |
+| [cowsay](https://pypi.org/project/cowsay/)               | `asdf plugin add cowsay https://github.com/amrox/asdf-pyapp.git`        |       |
+| [doit](https://pypi.org/project/doit/)                   | `asdf plugin add doit https://github.com/amrox/asdf-pyapp.git`          |       |
+| [flake8](https://pypi.org/project/flake8/)               | `asdf plugin add flake8 https://github.com/amrox/asdf-pyapp.git`        |       |
+| [hy](https://pypi.org/project/hy/)                       | `asdf plugin add hy https://github.com/amrox/asdf-pyapp.git`            |       |
+| [meson](https://pypi.org/project/meson/)                 | `asdf plugin add meson https://github.com/amrox/asdf-pyapp.git`         |       |
+| [mypy](https://pypi.org/project/mypy/)                   | `asdf plugin add mypy https://github.com/amrox/asdf-pyapp.git`          |       |
+| [pipenv](https://pypi.org/project/pipenv/)               | `asdf plugin add pipenv https://github.com/amrox/asdf-pyapp.git`        |       |
+| [pre-commit](https://pypi.org/project/pre-commit/)       | `asdf plugin add pre-commit https://github.com/amrox/asdf-pyapp.git`    |       |
+| [salt](https://pypi.org/project/salt/)                   | `asdf plugin add salt https://github.com/amrox/asdf-pyapp.git`          |       |
+| [sphinx](https://pypi.org/project/Sphinx/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
+| [yawsso](https://pypi.org/project/yawsso/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
+| [youtube-dl](https://pypi.org/project/youtube-dl/)       | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to install & manage versions.
 
@@ -126,6 +152,7 @@ conan 1.36.0@3.8.5
 
 ## Environment Variables
 
+- `ASDF_PYAPP_INCLUDE_DEPS` - when set to `1`, this plugin will consider the executables of the dependencies of the installed package as well. For example, when installing `ansible`, the `ansible` command actually comes from its depency, `ansible-core`. This is the same as Pipx's `--include-deps` flag.
 - `ASDF_PYAPP_DEFAULT_PYTHON_PATH` - Path to a `python`/`python3` binary this plugin should use. Default is unset. See Python Resolution section for more details.
 - `ASDF_PYAPP_VENV_COPY_MODE`:
   - `0`: (default) Add `--copies` flag to venvs created with a specific Python version. Symlinks otherwise.

--- a/bin/post-plugin-add
+++ b/bin/post-plugin-add
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${ASDF_PYAPP_INCLUDE_DEPS-}" = "1" ]]; then
+  touch "$ASDF_PLUGIN_PATH/include_deps"
+fi

--- a/lib/helpers/link_apps/link_apps.py
+++ b/lib/helpers/link_apps/link_apps.py
@@ -10,7 +10,11 @@ def link_apps(
     venv_path: Path, package_name: str, dest_dir: Path, force: bool = False
 ) -> None:
     venv = Venv(venv_path)
-    apps = venv.get_venv_metadata_for_package(package_name, set()).apps
+    venv_metadata = venv.get_venv_metadata_for_package(package_name, set())
+    apps = venv_metadata.apps
+
+    if (Path(__file__).parents[3] / "include_deps").exists():
+        apps = venv_metadata.apps_of_dependencies + apps
 
     os.makedirs(dest_dir, exist_ok=True)
 


### PR DESCRIPTION
Solves #11.

When setting the envvar `ASDF_PYAPP_INCLUDE_DEPS` to `1`, the plugin will now symlink binaries of dependencies of the installed app. This helps with `dbt` installs, as well as `ansible`.
