### PR TITLE
fix: upgrade setuptools in virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,29 +47,29 @@ cowsay "Hi!"
 
 This is a non-exhaustive list of Python Applications that work with this plugin.
 
-| App                                                      | Command to add Plugin                                                   | Notes |
-| -------------------------------------------------------- | ----------------------------------------------------------------------- | ----- |
-| [ansible-base](https://pypi.org/project/ansible-base/)   | `asdf plugin add ansible-base https://github.com/amrox/asdf-pyapp.git`  |       |
-| [ansible-core](https://pypi.org/project/ansible-core/)   | `asdf plugin add ansible-core https://github.com/amrox/asdf-pyapp.git`  |       |
-| [awscli](https://pypi.org/project/awscli/)               | `asdf plugin add awscli https://github.com/amrox/asdf-pyapp.git`        |       |
-| [awsebcli](https://pypi.org/project/awsebcli/)           | `asdf plugin add awsebcli https://github.com/amrox/asdf-pyapp.git`      |       |
-| [aws-sam-cli](https://pypi.org/project/aws-sam-cli/)     | `asdf plugin add aws-sam-cli https://github.com/amrox/asdf-pyapp.git`   |       |
-| [aws-ssm-tools](https://pypi.org/project/aws-ssm-tools/) | `asdf plugin add aws-ssm-tools https://github.com/amrox/asdf-pyapp.git` |       |
-| [black](https://pypi.org/project/black/)                 | `asdf plugin add black https://github.com/amrox/asdf-pyapp.git`         |       |
-| [bpython](https://pypi.org/project/bpython/)             | `asdf plugin add bpython https://github.com/amrox/asdf-pyapp.git`       |       |
-| [conan](https://pypi.org/project/conan/)                 | `asdf plugin add conan https://github.com/amrox/asdf-pyapp.git`         |       |
-| [cowsay](https://pypi.org/project/cowsay/)               | `asdf plugin add cowsay https://github.com/amrox/asdf-pyapp.git`        |       |
-| [doit](https://pypi.org/project/doit/)                   | `asdf plugin add doit https://github.com/amrox/asdf-pyapp.git`          |       |
-| [flake8](https://pypi.org/project/flake8/)               | `asdf plugin add flake8 https://github.com/amrox/asdf-pyapp.git`        |       |
-| [hy](https://pypi.org/project/hy/)                       | `asdf plugin add hy https://github.com/amrox/asdf-pyapp.git`            |       |
-| [meson](https://pypi.org/project/meson/)                 | `asdf plugin add meson https://github.com/amrox/asdf-pyapp.git`         |       |
-| [mypy](https://pypi.org/project/mypy/)                   | `asdf plugin add mypy https://github.com/amrox/asdf-pyapp.git`          |       |
-| [pipenv](https://pypi.org/project/pipenv/)               | `asdf plugin add pipenv https://github.com/amrox/asdf-pyapp.git`        |       |
-| [pre-commit](https://pypi.org/project/pre-commit/)       | `asdf plugin add pre-commit https://github.com/amrox/asdf-pyapp.git`    |       |
-| [salt](https://pypi.org/project/salt/)                   | `asdf plugin add salt https://github.com/amrox/asdf-pyapp.git`          |       |
-| [sphinx](https://pypi.org/project/Sphinx/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
-| [yawsso](https://pypi.org/project/yawsso/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
-| [youtube-dl](https://pypi.org/project/youtube-dl/)       | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |       |
+| App                                                      | Command to add Plugin                                                   | Notes                                                              |
+| -------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [ansible-base](https://pypi.org/project/ansible-base/)   | `asdf plugin add ansible-base https://github.com/amrox/asdf-pyapp.git`  |                                                                    |
+| [ansible-core](https://pypi.org/project/ansible-core/)   | `asdf plugin add ansible-core https://github.com/amrox/asdf-pyapp.git`  |                                                                    |
+| [awscli](https://pypi.org/project/awscli/)               | `asdf plugin add awscli https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [awsebcli](https://pypi.org/project/awsebcli/)           | `asdf plugin add awsebcli https://github.com/amrox/asdf-pyapp.git`      |                                                                    |
+| [aws-sam-cli](https://pypi.org/project/aws-sam-cli/)     | `asdf plugin add aws-sam-cli https://github.com/amrox/asdf-pyapp.git`   |                                                                    |
+| [aws-ssm-tools](https://pypi.org/project/aws-ssm-tools/) | `asdf plugin add aws-ssm-tools https://github.com/amrox/asdf-pyapp.git` |                                                                    |
+| [black](https://pypi.org/project/black/)                 | `asdf plugin add black https://github.com/amrox/asdf-pyapp.git`         |                                                                    |
+| [bpython](https://pypi.org/project/bpython/)             | `asdf plugin add bpython https://github.com/amrox/asdf-pyapp.git`       |                                                                    |
+| [conan](https://pypi.org/project/conan/)                 | `asdf plugin add conan https://github.com/amrox/asdf-pyapp.git`         |                                                                    |
+| [cowsay](https://pypi.org/project/cowsay/)               | `asdf plugin add cowsay https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [doit](https://pypi.org/project/doit/)                   | `asdf plugin add doit https://github.com/amrox/asdf-pyapp.git`          |                                                                    |
+| [flake8](https://pypi.org/project/flake8/)               | `asdf plugin add flake8 https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [hy](https://pypi.org/project/hy/)                       | `asdf plugin add hy https://github.com/amrox/asdf-pyapp.git`            | The latest stable version of hy (0.20.0 atm) requires python > 3.8 |
+| [meson](https://pypi.org/project/meson/)                 | `asdf plugin add meson https://github.com/amrox/asdf-pyapp.git`         |                                                                    |
+| [mypy](https://pypi.org/project/mypy/)                   | `asdf plugin add mypy https://github.com/amrox/asdf-pyapp.git`          |                                                                    |
+| [pipenv](https://pypi.org/project/pipenv/)               | `asdf plugin add pipenv https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [pre-commit](https://pypi.org/project/pre-commit/)       | `asdf plugin add pre-commit https://github.com/amrox/asdf-pyapp.git`    |                                                                    |
+| [salt](https://pypi.org/project/salt/)                   | `asdf plugin add salt https://github.com/amrox/asdf-pyapp.git`          |                                                                    |
+| [sphinx](https://pypi.org/project/Sphinx/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [yawsso](https://pypi.org/project/yawsso/)               | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
+| [youtube-dl](https://pypi.org/project/youtube-dl/)       | `asdf plugin add sphinx https://github.com/amrox/asdf-pyapp.git`        |                                                                    |
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to install & manage versions.
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -204,6 +204,8 @@ install_version() {
   # Make a venv for the app
   local venv_path="$install_path"/venv
   "$ASDF_PYAPP_RESOLVED_PYTHON_PATH" -m venv ${venv_args[@]+"${venv_args[@]}"} "$venv_path"
+  # setuptools might be upgraded by itself https://stackoverflow.com/a/71239956/4468
+  "$venv_path"/bin/python3 -m pip install ${pip_args[@]+"${pip_args[@]}"} --upgrade setuptools
   "$venv_path"/bin/python3 -m pip install ${pip_args[@]+"${pip_args[@]}"} --upgrade pip wheel
 
   # Install the App

--- a/test/integration-tests.bats
+++ b/test/integration-tests.bats
@@ -426,7 +426,13 @@ check_app() {
 }
 
 @test "check app hy latest" {
-  check_app hy latest hy --version
+  skip
+  # hy latest (0.20.0 atm) does not install with python 3.6
+  check_app hy latest --version
+}
+
+@test "check app hy 0.20.0@3.8.2" {
+  check_app hy 0.20.0@3.8.2 hy --version
 }
 
 @test "check app meson latest" {


### PR DESCRIPTION

local test run:
```
❯ ./bats/bin/bats  --verbose-run integration-tests.bats
integration-tests.bats
 ✓ install with system python no asdf
 ✓ install with system python via asdf
 ✓ install with asdf python 3.8.10
 ✓ install with asdf python 3.5.10 system python 3.6
 ✓ install with asdf python 3.5.10 no system python3
 ✓ check latest with pip version 19.3
 ✓ check latest with pip version 20.0
 ✓ check latest with pip version 20.1
 ✓ check latest with pip version 20.2
 ✓ check latest with pip version 20.3
 ✓ check latest with pip version 21.3
 ✓ check $ASDF_PYAPP_DEFAULT_PYTHON_PATH works
 ✓ install with local python in direnv
 ✓ install with python plugin integration
 ✓ install with python plugin integration without python plugin installed
 ✓ install with asdf direnv no shims no global python
 ✓ install with asdf direnv no shims with global python
 ✓ check ASDF_PYAPP_VENV_COPY_MODE=1
 ✓ check app ansible-base latest
 ✓ check app ansible-core latest
 ✓ check app awscli latest
 ✓ check app awsebcli latest
 ✓ check app aws-sam-cli latest
 - check app black latest (skipped)
 ✓ check app black 21.5b2
 ✓ check app bpython latest
 ✓ check app conan latest
 ✓ check app doit latest
 ✓ check app flake8 latest
 - check app hy latest (skipped)
 ✓ check app hy 0.20.0@3.8.2
 ✓ check app meson latest
 ✓ check app mypy latest
 ✓ check app pipenv latest
 ✓ check app salt latest
 ✓ check app sphinx latest
 ✓ check app aws-ssm-tools latest
 ✓ check app yawsso latest
 ✓ check app pre-commit latest

39 tests, 0 failures, 2 skipped
```