### PR TITLE
Fix getting package versions

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -137,9 +137,11 @@ get_package_versions() {
 
   local pip_install_args=()
   local version_output_raw
+  local regex
 
   if [ "${pip_version_major}" -ge 24 ]; then
     version_output_raw=$("${ASDF_PYAPP_RESOLVED_PYTHON_PATH}" -m pip index versions "${package}" 2>&1) || true
+    regex='.*Available versions:(.*)'
   else
     # we rely on the "legacy resolver" to get versions, which was introduced in 20.3
     if [ "${pip_version_major}" -ge 21 ] ||
@@ -147,9 +149,9 @@ get_package_versions() {
       pip_install_args+=("--use-deprecated=legacy-resolver")
     fi
     version_output_raw=$("${ASDF_PYAPP_RESOLVED_PYTHON_PATH}" -m pip install ${pip_install_args[@]+"${pip_install_args[@]}"} "${package}==" 2>&1) || true
+    regex='.*from versions:(.*)\)'
   fi
 
-  local regex='.*from versions:(.*)\)'
   if [[ $version_output_raw =~ $regex ]]; then
     local version_substring="${BASH_REMATCH[1]//','/}"
     # trim whitespace with 'xargs echo' and convert spaces to newlines with 'tr'

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -138,12 +138,16 @@ get_package_versions() {
   local pip_install_args=()
   local version_output_raw
 
-  # we rely on the "legacy resolver" to get versions, which was introduced in 20.3
-  if [ "${pip_version_major}" -ge 21 ] ||
-    { [ "${pip_version_major}" -eq 20 ] && [ "${pip_version_minor}" -ge 3 ]; }; then
-    pip_install_args+=("--use-deprecated=legacy-resolver")
+  if [ "${pip_version_major}" -ge 24 ]; then
+    version_output_raw=$("${ASDF_PYAPP_RESOLVED_PYTHON_PATH}" -m pip index versions "${package}" 2>&1) || true
+  else
+    # we rely on the "legacy resolver" to get versions, which was introduced in 20.3
+    if [ "${pip_version_major}" -ge 21 ] ||
+      { [ "${pip_version_major}" -eq 20 ] && [ "${pip_version_minor}" -ge 3 ]; }; then
+      pip_install_args+=("--use-deprecated=legacy-resolver")
+    fi
+    version_output_raw=$("${ASDF_PYAPP_RESOLVED_PYTHON_PATH}" -m pip install ${pip_install_args[@]+"${pip_install_args[@]}"} "${package}==" 2>&1) || true
   fi
-  version_output_raw=$("${ASDF_PYAPP_RESOLVED_PYTHON_PATH}" -m pip install ${pip_install_args[@]+"${pip_install_args[@]}"} "${package}==" 2>&1) || true
 
   local regex='.*from versions:(.*)\)'
   if [[ $version_output_raw =~ $regex ]]; then

--- a/test/docker/bionic/Dockerfile
+++ b/test/docker/bionic/Dockerfile
@@ -43,6 +43,7 @@ RUN echo ". $HOME/.asdf/asdf.sh" >> ~/.profile
 RUN source /root/.asdf/asdf.sh && asdf plugin add python
 RUN source /root/.asdf/asdf.sh && asdf install python 3.5.10
 RUN source /root/.asdf/asdf.sh && asdf install python 3.8.10
+RUN source /root/.asdf/asdf.sh && asdf install python 3.12.7
 
 RUN source /root/.asdf/asdf.sh && asdf plugin add direnv
 RUN source /root/.asdf/asdf.sh && asdf install direnv 2.28.0

--- a/test/integration-tests.bats
+++ b/test/integration-tests.bats
@@ -217,6 +217,24 @@ teardown() {
   refute_output --partial "asdf-pyapp: [ERROR]"
 }
 
+@test "check latest with pip version 24.2" {
+
+  local pip_version=24.2
+
+  in_container asdf global python 3.12.7
+
+  in_container python3 -m pip install --upgrade pip=="$pip_version"
+
+  run in_container python3 -m pip --version
+  assert_output --partial "$pip_version"
+
+  in_container asdf plugin add cowsay /root/asdf-pyapp
+  run in_container eval "ASDF_PYAPP_DEBUG=1 asdf list all cowsay"
+  # TODO: "asdf list all" seems to mask return codes. It exits 0 even if we
+  # exit nonzero in our function. So just check output for errors for now...
+  refute_output --partial "asdf-pyapp: [ERROR]"
+}
+
 @test "check \$ASDF_PYAPP_DEFAULT_PYTHON_PATH works" {
   # When an app is installed without a python version specified,
   # the asdf-pyapp defaults to python3 in our $PATH, which is the

--- a/test/integration-tests.bats
+++ b/test/integration-tests.bats
@@ -388,7 +388,7 @@ setup_direnv() {
 
 @test "check ASDF_PYAPP_INCLUDE_DEPS=0 doesn't install executables of dependencies" {
 
-  in_container asdf global python 3.8.10
+  in_container asdf global python 3.12.7
 
   in_container eval "ASDF_PYAPP_INCLUDE_DEPS=0 asdf plugin add ansible /root/asdf-pyapp"
   in_container asdf install ansible latest
@@ -400,7 +400,7 @@ setup_direnv() {
 
 @test "check ASDF_PYAPP_INCLUDE_DEPS=1 installs executables of dependencies" {
 
-  in_container asdf global python 3.8.10
+  in_container asdf global python 3.12.7
 
   in_container eval "ASDF_PYAPP_INCLUDE_DEPS=1 asdf plugin add ansible /root/asdf-pyapp"
   in_container asdf install ansible latest


### PR DESCRIPTION
on python ~3.12 `list all` command returns
```
Plugin ansible's list-all callback script failed with output:
asdf-pyapp: [ERROR] Unable to parse versions for 'ansible'
```
because command `python -m pip install --use-deprecated=legacy-resolver ansible==` returns
```
ERROR: Invalid requirement: 'ansible==': Expected end or semicolon (after name and no valid version specifier)
    ansible==
```